### PR TITLE
add "main" entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "Routing Backbone with style \\o/",
   "author": "Carl OGREN <rascarlito@gmail.com>",
+  "main": "dist/backbone.highway.min.js",
   "keywords": [
     "backbone",
     "router",


### PR DESCRIPTION
this enables requiring the module in the commonJS module system.
i.e.  `var Router = require('backbone-highway');`
server or client side !
